### PR TITLE
Bob speed improvements and sense/antisense entity fixes

### DIFF
--- a/bin/wrangleRNASeq.R
+++ b/bin/wrangleRNASeq.R
@@ -1,21 +1,28 @@
 #!/usr/local/bin/Rscript
 
- library(tidyverse)
- library(study.wrangler)
+library(tidyverse)
+
+# use study.wrangler v1.0.14 or above for speed
+library(study.wrangler)
 
 
 read_counts_data <- function(filename) {
 
-  # read in as all-character  
-  suppressMessages(
-    data <- read_tsv(
-      filename,
-      col_names = FALSE,
-      col_types = cols(.default = "c")
-    ) %>%
-      # and transpose
-      t() %>% as_tibble(.name_repair = 'unique')
-  )
+  # read in as all-character
+  data <- read_tsv(
+    filename,
+    col_names = FALSE,
+    col_types = cols(.default = "c")
+  ) %>%
+    # and transpose
+    as.matrix() %>%
+    t()
+
+  # make colnames manually to avoid pairwise compute
+  colnames(data) <- sprintf("V%i", seq_len(ncol(data)))
+
+  # wrap it in a tibble with NO name repair overhead
+  data <- as_tibble(data, .name_repair = "minimal")
   
   # Extract the header row
   headers <- data %>% slice_head(n = 1) %>% unlist(use.names = FALSE)

--- a/bin/wrangleRNASeq.R
+++ b/bin/wrangleRNASeq.R
@@ -7,14 +7,15 @@
 read_counts_data <- function(filename) {
 
   # read in as all-character  
-  data <- read_tsv(
-    filename,
-    col_names = FALSE,
-    col_types = cols(.default = "c")
-  ) %>%
-    # and transpose
-    t() %>%
-    as_tibble()
+  suppressMessages(
+    data <- read_tsv(
+      filename,
+      col_names = FALSE,
+      col_types = cols(.default = "c")
+    ) %>%
+      # and transpose
+      t() %>% as_tibble(.name_repair = 'unique')
+  )
   
   # Extract the header row
   headers <- data %>% slice_head(n = 1) %>% unlist(use.names = FALSE)
@@ -47,7 +48,7 @@ read_counts_data <- function(filename) {
 rename_counts_by_strandedness <- function(counts_list, orgAbbrev) {
   if (length(counts_list) == 1) {
     # Only one file → label it unstranded
-    names(counts_list) <- "unstranded"
+    names(counts_list) <- paste0("unstranded_", orgAbbrev)
     return(counts_list)
   }
   
@@ -73,7 +74,7 @@ rename_counts_by_strandedness <- function(counts_list, orgAbbrev) {
     stop("Strandedness could not be consistently determined for ", names(counts_list))
   }
 
-  suffix = paste0("_", orgAbbrev);
+  suffix = paste0("_", orgAbbrev)
 
   names(counts_list) = paste0(names(counts_list), suffix) 
   

--- a/bin/wrangleRNASeq.R
+++ b/bin/wrangleRNASeq.R
@@ -42,7 +42,8 @@ read_counts_data <- function(filename) {
       ),
       assay.ID = sample.ID
     ) %>%
-    relocate(assay.ID, .after = sample.ID)
+    relocate(assay.ID, .after = sample.ID) %>%
+    select(-starts_with('__'))
   
   return(data)
 }


### PR DESCRIPTION
I've added a commit https://github.com/VEuPathDB/study-dealer-nextflow/pull/2/commits/449944afd1334fecd89bd0f8f5a5ee9d58f0e411 that obviates the `grep -v __` step in nextflow. It's harmless to keep both.