### PR TITLE
Let entity stable ids be generated from already-unique entity.name

### DIFF
--- a/bin/wrangleRNASeq.R
+++ b/bin/wrangleRNASeq.R
@@ -347,7 +347,6 @@ counts_to_entity <- function(tbl, orgAbbrev) {
       name = glue("{orgAbbrev} htseq counts"),
       display_name = glue("{orgAbbrev} htseq counts"),
       display_name_plural = glue("{orgAbbrev} htseq counts"),
-      stable_id = "GENE_EXPRESSION_RNASEQ_DATA",
       skip_type_convert = TRUE
     ) %>%
       set_parents('sample', 'sample.ID') %>%
@@ -378,7 +377,6 @@ wgcna_to_entity <- function(tbl, name, orgAbbrev) {
       name = glue("{orgAbbrev} eigengene"),
       display_name = glue("{orgAbbrev} Eigengene (wgcna)"),
       display_name_plural = glue("{orgAbbrev} Eigengenes (wgcna)"),
-      stable_id = "WGCNA_DATA",
       skip_type_convert = TRUE
       #TO DO, description = ???
     ) %>%


### PR DESCRIPTION
Avoids duplicate stable IDs in complex studies. Auto-digest-based generation will be used (based on `entity.name`)

Definitely seen for WGCNA

But also likely to be an issue for RNASeq with antisense + sense entities?

Do we validate for this? No we don't. Adding this in another `study-wrangler` PR coming soon.