### PR TITLE
Add rank variables to four piggyBac/phenotype studies for EDA gene gr…

### DIFF
--- a/lib/R/phenotype/PlasmoDB_pberANKA_Bushell_functional_profiling_Phenotype_RSRC.R
+++ b/lib/R/phenotype/PlasmoDB_pberANKA_Bushell_functional_profiling_Phenotype_RSRC.R
@@ -23,18 +23,24 @@ wrangle <- function() {
     redetect_column_as_id('ID')
   
   
-  # update columns as needed
+  ## create rank variable and update metadata
   genePhenotype <- genePhenotype %>%
+    modify_data(mutate(
+      relative_growth_rate.rank = rank(relative_growth_rate)
+    )) %>%
+    sync_variable_metadata() %>%
+
     set_variable_metadata('gene', stable_id = "VEUPATHDB_GENE_ID", display_name = "Gene", provider_label=list("gene"), display_order=1, hidden=list('variableTree'))  %>%
     set_variable_metadata('phenotype', display_order=2, display_name = "Phenotype", definition = "Phenotype") %>%
-    set_variable_metadata('relative_growth_rate', display_order=3, display_name = "Relative Growth Rate", definition = "Relative Growth Rate") %>%
-    set_variable_metadata('confidence', display_order=4, display_name = "Confidence", definition = "Confidence") %>%
-    set_variable_metadata('expected_variance', display_order=5, display_name = "Expected Variance", definition = "Expected Variance") %>%
-    set_variable_metadata('RGR_CI_low', display_order=6, display_name = "RGR CI Low", definition = "RGR CI Low") %>%
-    set_variable_metadata('RGR_CI_high', display_order=7, display_name = "RGR CI High", definition = "RGR CI High") %>%
-    set_variable_metadata('times_analyzed', display_order=8, display_name = "Times Analyzed", definition = "Times Analyzed") %>%
-    set_variable_metadata('construct', display_order=9, display_name = "Targeting Vector", definition = "Targeting Vector") %>%
-    set_variable_metadata('notes', display_order=10, display_name = "Notes", definition = "Notes")
+    set_variable_metadata('relative_growth_rate.rank', display_order=3, display_name = "Relative Growth Rate Rank", hidden=list('variableTree'), definition="Rank of Relative Growth Rate") %>%
+    set_variable_metadata('relative_growth_rate', display_order=4, display_name = "Relative Growth Rate", definition = "Relative Growth Rate") %>%
+    set_variable_metadata('confidence', display_order=5, display_name = "Confidence", definition = "Confidence") %>%
+    set_variable_metadata('expected_variance', display_order=6, display_name = "Expected Variance", definition = "Expected Variance") %>%
+    set_variable_metadata('RGR_CI_low', display_order=7, display_name = "RGR CI Low", definition = "RGR CI Low") %>%
+    set_variable_metadata('RGR_CI_high', display_order=8, display_name = "RGR CI High", definition = "RGR CI High") %>%
+    set_variable_metadata('times_analyzed', display_order=9, display_name = "Times Analyzed", definition = "Times Analyzed") %>%
+    set_variable_metadata('construct', display_order=10, display_name = "Targeting Vector", definition = "Targeting Vector") %>%
+    set_variable_metadata('notes', display_order=11, display_name = "Notes", definition = "Notes")
   
   study = study(name="TEMP_STUDY_NAME", genePhenotype)
 

--- a/lib/R/phenotype/PlasmoDB_pfal3D7_pB_mutagenesis_MIS_MFS_Phenotype_RSRC.R
+++ b/lib/R/phenotype/PlasmoDB_pfal3D7_pB_mutagenesis_MIS_MFS_Phenotype_RSRC.R
@@ -24,10 +24,18 @@ wrangle <- function() {
     sync_variable_metadata() %>%
     redetect_column_as_id('ID')
 
-  ## update columns as needed
+  ## create rank variables and update metadata
   genePhenotype <- genePhenotype %>%
-    set_variable_metadata('mutant.fitness.score', display_order=2, display_name = "Mutant Fitness Score", definition="Mutant fitness score") %>%
-    set_variable_metadata('mutagenesis.index.score', display_order=3, display_name = "Mutagenesis Index Score", definition="Mutagenesis index score")
+    modify_data(mutate(
+      mutant.fitness.score.rank = rank(mutant.fitness.score),
+      mutagenesis.index.score.rank = rank(mutagenesis.index.score)
+    )) %>%
+    sync_variable_metadata() %>%
+
+    set_variable_metadata('mutant.fitness.score.rank', display_order=2, display_name = "Mutant Fitness Score Rank", hidden=list('variableTree'), definition="Rank of Mutant Fitness Score") %>%
+    set_variable_metadata('mutant.fitness.score', display_order=3, display_name = "Mutant Fitness Score", definition="Mutant fitness score") %>%
+    set_variable_metadata('mutagenesis.index.score.rank', display_order=4, display_name = "Mutagenesis Index Score Rank", hidden=list('variableTree'), definition="Rank of Mutagenesis Index Score") %>%
+    set_variable_metadata('mutagenesis.index.score', display_order=5, display_name = "Mutagenesis Index Score", definition="Mutagenesis index score")
 
   study = study(name="TEMP_STUDY_NAME", genePhenotype)
 

--- a/lib/R/phenotype/PlasmoDB_pknoA1H1_piggyBac_mutagenesis_MIS_MFS_Phenotype_RSRC.R
+++ b/lib/R/phenotype/PlasmoDB_pknoA1H1_piggyBac_mutagenesis_MIS_MFS_Phenotype_RSRC.R
@@ -23,10 +23,23 @@ wrangle <- function() {
    sync_variable_metadata() %>%
    redetect_column_as_id('ID')
 
+  ## create rank variables and update metadata
   genePhenotype <- genePhenotype %>%
+    modify_data(mutate(
+      MIS.plus.rank = rank(MIS.plus),
+      MIS.rank = rank(MIS),
+      MFS.rank = rank(MFS)
+    )) %>%
+    sync_variable_metadata() %>%
+
     set_variable_metadata('gene', stable_id = "VEUPATHDB_GENE_ID", display_name = "Gene", provider_label=list("gene"), display_order=1, hidden=list('variableTree')) %>%
-    set_variable_metadata('MIS.plus', display_order=2, display_name = "MIS Plus", definition = "MIS Plus") %>%
-    set_variable_metadata('mutability', display_order=3, display_name = "Mutability in CDS", definition = "Mutability in CDS")
+    set_variable_metadata('mutability', display_order=2, display_name = "Mutability in CDS", definition = "Mutability in CDS") %>%
+    set_variable_metadata('MIS.plus.rank', display_order=3, display_name = "MIS Plus Rank", hidden=list('variableTree'), definition="Rank of MIS Plus") %>%
+    set_variable_metadata('MIS.plus', display_order=4, display_name = "MIS Plus", definition = "MIS Plus") %>%
+    set_variable_metadata('MIS.rank', display_order=5, display_name = "MIS Rank", hidden=list('variableTree'), definition="Rank of MIS") %>%
+    set_variable_metadata('MIS', display_order=6, display_name = "MIS", definition = "MIS") %>%
+    set_variable_metadata('MFS.rank', display_order=7, display_name = "MFS Rank", hidden=list('variableTree'), definition="Rank of MFS") %>%
+    set_variable_metadata('MFS', display_order=8, display_name = "MFS", definition = "MFS")
   
   study = study(name="TEMP_STUDY_NAME", genePhenotype)
 

--- a/lib/R/phenotype/PlasmoDB_pknoH_piggyBac_mutagenesis_HME_MIS_OIS_Phenotype_RSRC.R
+++ b/lib/R/phenotype/PlasmoDB_pknoH_piggyBac_mutagenesis_HME_MIS_OIS_Phenotype_RSRC.R
@@ -23,10 +23,19 @@ wrangle <- function() {
    sync_variable_metadata() %>%
    redetect_column_as_id('ID')
 
+  ## create rank variables and update metadata
   genePhenotype <- genePhenotype %>%
+    modify_data(mutate(
+      Hybrid.model.score.rank = rank(Hybrid.model.score),
+      Occupancy.index.score.rank = rank(Occupancy.index.score)
+    )) %>%
+    sync_variable_metadata() %>%
+
     set_variable_metadata('gene', stable_id = "VEUPATHDB_GENE_ID", display_name = "Gene", provider_label=list("gene"), display_order=1, hidden=list('variableTree')) %>%
-    set_variable_metadata('Hybrid.model.score', display_order=2, display_name = "Hybrid Model Score", definition = "Hybrid Model Score") %>%
-    set_variable_metadata('Occupancy.index.score', display_order=3, display_name = "Occupancy Index Score", definition = "Occupancy Index Score")
+    set_variable_metadata('Hybrid.model.score.rank', display_order=2, display_name = "Hybrid Model Score Rank", hidden=list('variableTree'), definition="Rank of Hybrid Model Score") %>%
+    set_variable_metadata('Hybrid.model.score', display_order=3, display_name = "Hybrid Model Score", definition = "Hybrid Model Score") %>%
+    set_variable_metadata('Occupancy.index.score.rank', display_order=4, display_name = "Occupancy Index Score Rank", hidden=list('variableTree'), definition="Rank of Occupancy Index Score") %>%
+    set_variable_metadata('Occupancy.index.score', display_order=5, display_name = "Occupancy Index Score", definition = "Occupancy Index Score")
   
   study = study(name="TEMP_STUDY_NAME", genePhenotype)
 


### PR DESCRIPTION
…aphs

Added rank() calculations and associated hidden metadata for score variables in preparation for rank vs score scatterplots:
- pfal3D7_pB_mutagenesis: Mutant Fitness Score Rank, Mutagenesis Index Score Rank
- pknoA1H1_piggyBac: MIS Plus Rank, MIS Rank, MFS Rank
- pknoH_piggyBac: Hybrid Model Score Rank, Occupancy Index Score Rank
- pberANKA_Bushell: Relative Growth Rate Rank

Follows the same pattern used in the ToxoDB CRISPR phenotype studies.