### PR TITLE
Featured variables and display ordering for RNASeq assay and sample entities

### DIFF
--- a/bin/wrangleRNASeq.R
+++ b/bin/wrangleRNASeq.R
@@ -358,8 +358,8 @@ counts_to_entity <- function(tbl, orgAbbrev) {
   # Set display names for count columns
   if ("Sense.Count" %in% colnames(tbl)) {
     assays <- assays %>%
-      set_variable_metadata('Sense.Count', display_name = "Sense Count", stable_id="SEQUENCE_READ_COUNT_SENSE") %>%
-      set_variable_metadata('Antisense.Count', display_name = "Antisense Count", stable_id="SEQUENCE_READ_COUNT_ANTISENSE")
+      set_variable_metadata('Sense.Count', display_name = "Sense Count", stable_id="SEQUENCE_READ_COUNT_SENSE", is_featured = TRUE, display_order = 1) %>%
+      set_variable_metadata('Antisense.Count', display_name = "Antisense Count", stable_id="SEQUENCE_READ_COUNT_ANTISENSE", display_order = 2)
   } else if ("Count" %in% colnames(tbl)) {
     assays <- assays %>%
       set_variable_metadata('Count', display_name = "Count", stable_id="SEQUENCE_READ_COUNT")

--- a/bin/wrangleRNASeq.R
+++ b/bin/wrangleRNASeq.R
@@ -470,8 +470,21 @@ wrangle <- function(studyName) {
 
   # the entity will have the name 'sample'
   samples <- benchmark("process_sample_metadata", {
-    entity_from_stf(file_discovery$sample_tsv_file) %>%
+    samples_entity <- entity_from_stf(file_discovery$sample_tsv_file) %>%
       set_variable_metadata('sample.ID', display_name = "Sample ID", hidden=list('variableTree'))
+
+    variable_names <- samples_entity %>% get_variable_metadata() %>% pull('variable')
+
+    if ('label' %in% variable_names) {
+      samples_entity <- samples_entity %>% set_variable_metadata('label', is_featured = TRUE)
+      variable_names <- c('label', variable_names[variable_names != 'label'])
+    }
+
+    for (i in seq_along(variable_names)) {
+      samples_entity <- samples_entity %>% set_variable_metadata(variable_names[[i]], display_order = i)
+    }
+
+    samples_entity
   })
 
 


### PR DESCRIPTION
- `label` variable on the sample entity is marked as featured and sorted to position 1 (when present); all other sample variables receive explicit `display_order` values based on their original order
- For stranded RNA-seq assay entities, `Sense.Count` is marked as featured with `display_order = 1` and `Antisense.Count` gets `display_order = 2`; unstranded studies are unaffected
