### PR TITLE
Use the new `set_variable_vocabulary_order()` function for 'RFLP genope' variable

### DIFF
--- a/lib/R/rflp/ToxoDB_Combined_RFLP_RSRC.R
+++ b/lib/R/rflp/ToxoDB_Combined_RFLP_RSRC.R
@@ -96,11 +96,10 @@ wrangle <- function() {
   rflp_entity <- rflp_entity %>%
     set_variable_display_names_from_provider_labels()
 
-  # Create unique ID and set as primary key
-  ## rflp_entity <- rflp_entity %>%
-  ##   modify_data(mutate(ID = row_number())) %>%
-  ##   sync_variable_metadata() %>%
-  ##   redetect_column_as_id('ID')
+  # Create synthetic row-number ID so Isolate_ID can be treated as a regular variable
+  rflp_entity <- rflp_entity %>%
+    create_serial_id_column('ID') %>%
+    redetect_columns_as_variables('Isolate_ID')
 
   # custom sort function for number-like ID column
   sort_numbers_first <- function(vec) {

--- a/lib/R/rflp/ToxoDB_Combined_RFLP_RSRC.R
+++ b/lib/R/rflp/ToxoDB_Combined_RFLP_RSRC.R
@@ -1,6 +1,13 @@
 library(tidyverse)
 library(study.wrangler)
 
+if (packageVersion("study.wrangler") < "1.0.45") {
+  stop(sprintf(
+    "study.wrangler >= 1.0.45 is required by ToxoDB_Combined_RFLP_RSRC (found %s). Bump studyWranglerTag in nextflow.config.",
+    packageVersion("study.wrangler")
+  ))
+}
+
 wrangle <- function() {
   rm(list = ls())
 
@@ -95,6 +102,12 @@ wrangle <- function() {
   ##   sync_variable_metadata() %>%
   ##   redetect_column_as_id('ID')
 
+  # custom sort function for number-like ID column
+  sort_numbers_first <- function(vec) {
+    nums <- suppressWarnings(as.numeric(vec))
+    c(vec[!is.na(nums)][order(nums[!is.na(nums)])], sort(vec[is.na(nums)]))
+  }						    
+
   # Set specific variable metadata for key columns
   rflp_entity <- rflp_entity %>%
     set_variable_metadata('Dataset',
@@ -140,6 +153,7 @@ wrangle <- function() {
                           display_name = "RFLP genotype #",
                           definition = "RFLP genotype number. See the <a href=\"/a/app/static-content/ToxoDB/pcr-rflp-genotypes.html\">RFLP Genotype Reference</a> for details.",
                           display_order = 8) %>%
+    set_variable_vocabulary_order('ToxoDB_Genotype', sort_numbers_first) %>%
     set_variable_metadata('Organc',
                           display_name = "Organ",
                           display_order = 9,

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@ params {
     //datasetName = "tgonGT1_crisprPhenotype_CrisprScreen_RSRC" // this can be used to filter to a single dataset
     datasetName = "" // this can be used to filter to a single dataset
     multiDatasetStudies = "$baseDir/data/rnaseq_sample_reannotation/multiDatasetStudy.json"
-    studyWranglerTag = "1.0.27" // docker image tag for study-wrangler (use custom tag for local development)
+    studyWranglerTag = "1.0.45" // docker image tag for study-wrangler (use custom tag for local development)
     workflowPath = "${params.workflowDataDir}/*/*/${params.mode}"
     filePatterns = [ebiRnaSeqCounts: "${params.workflowPath}/*/nextflowAnalysisDir/nextflow_output/analysis_output/{countsForEda,merged-0.25-eigengenes}*",
                     rnaSeqCounts: "${params.workflowPath}/*/bulkrnaseq/analysisDir/nextflowAnalysisDir/nextflow_output/analysis_output/countsForEda*",


### PR DESCRIPTION
See [Slack thread](https://epvb.slack.com/archives/C01DS6HBY3Z/p1782221056093549) and this screenshot

<img width="1220" height="1408" alt="image" src="https://github.com/user-attachments/assets/b689dd6b-4dc0-4ea1-b257-93e8a42c2d31" />

---

This PR sets the order at wrangle-time. Can we do a one-off hack in the database to avoid reloading, or are we reloading soon anyway? The "bug" is cosmetic and not a dealbreaker.

## NOTE: this is untested (although the new wrangler function has been unit tested over in the study-wrangler repo)